### PR TITLE
feat: add DOMAIN variable to email templates and notifications for links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Domain Configuration (for email links, etc.)
+DOMAIN=http://localhost:3000
+
 # NextAuth Configuration
 NEXTAUTH_SECRET=$(openssl rand -base64 32)
 NEXTAUTH_URL=http://localhost:3000
@@ -9,8 +12,6 @@ ADMIN_PASSWORD=changeme123
 # Optional: override location of SQLite DB file (useful for CI or custom setups)
 # DB_DIR=/absolute/path/to/data/secret-santa.db
 
-# Domain Configuration
-# DOMAIN=http://example.site.com
 
 # SMTP Configuration (env-only for this deployment)
 # This repository is configured to read SMTP settings exclusively from

--- a/__tests__/lib/email-config.test.ts
+++ b/__tests__/lib/email-config.test.ts
@@ -1,0 +1,65 @@
+import { getEnvEmailConfig, isEmailConfigValid } from '@/lib/email-config';
+
+describe('Email Config helpers', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // clear cached env reads
+    process.env = { ...OLD_ENV };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('returns null when SMTP_SERVER is not set', () => {
+    delete process.env.SMTP_SERVER;
+    const cfg = getEnvEmailConfig();
+    expect(cfg).toBeNull();
+  });
+
+  it('parses environment variables and defaults port to 587', () => {
+    process.env.SMTP_SERVER = 'smtp.example.com';
+    delete process.env.SMTP_PORT;
+    process.env.SMTP_USERNAME = 'user';
+    process.env.SMTP_PASSWORD = 'pass';
+    process.env.FROM_EMAIL = 'noreply@example.com';
+
+    const cfg = getEnvEmailConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.smtp_server).toBe('smtp.example.com');
+    expect(cfg!.smtp_port).toBe(587);
+    expect(cfg!.smtp_username).toBe('user');
+    expect(cfg!.from_email).toBe('noreply@example.com');
+  });
+
+  it('validates minimal email config correctly', () => {
+    expect(isEmailConfigValid(null)).toBe(false);
+
+    const missingFrom = { smtp_server: 'smtp.example.com', smtp_port: 25 } as any;
+    expect(isEmailConfigValid(missingFrom)).toBe(false);
+
+    const missingServer = { smtp_port: 25, from_email: 'noreply@example.com' } as any;
+    expect(isEmailConfigValid(missingServer)).toBe(false);
+
+    const good = { smtp_server: 'smtp', smtp_port: 25, from_email: 'noreply@example.com' } as any;
+    expect(isEmailConfigValid(good)).toBe(true);
+  });
+
+  it('parses explicit SMTP_PORT and returns null for absent optional fields', () => {
+    process.env.SMTP_SERVER = 'smtp.example.com';
+    process.env.SMTP_PORT = '2525';
+    delete process.env.SMTP_USERNAME;
+    delete process.env.SMTP_PASSWORD;
+    delete process.env.FROM_EMAIL;
+
+    const cfg = getEnvEmailConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.smtp_port).toBe(2525);
+    expect(cfg!.smtp_username).toBeNull();
+    expect(cfg!.smtp_password).toBeNull();
+    expect(cfg!.from_email).toBeNull();
+    // Missing from_email should make the config invalid
+    expect(isEmailConfigValid(cfg)).toBe(false);
+  });
+});

--- a/__tests__/lib/email-templates.test.ts
+++ b/__tests__/lib/email-templates.test.ts
@@ -1,0 +1,65 @@
+import { renderEmailTemplate, getEmailSubject, getEmailHtml, loadEmailTemplate } from '@/lib/email-templates';
+
+describe('Email templates', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('replaces variables in template strings', () => {
+    const tpl = 'Hello {{name}}! Your code is {{code}}.';
+    const out = renderEmailTemplate(tpl, { name: 'Alice', code: '1234' });
+    expect(out).toBe('Hello Alice! Your code is 1234.');
+  });
+
+  it('replaces provided variables correctly (including "0")', () => {
+    const tpl = 'Count: {{count}}; Note: {{note}}';
+    const out = renderEmailTemplate(tpl, { count: '0', note: '' });
+    // '0' is a non-empty string and will be preserved by the implementation
+    expect(out).toBe('Count: 0; Note: ');
+  });
+
+  it('builds subject strings with variables', () => {
+    const subj = getEmailSubject('assignment-notification', { year: '2024', giver_name: 'Alice' });
+    expect(subj).toContain('Secret Santa 2024');
+    expect(subj).toContain('Alice');
+  });
+
+  it('loads and renders an actual template file and includes domain link', () => {
+    // Ensure DOMAIN is set so the template link is rendered
+    process.env.DOMAIN = 'http://localhost:3000';
+
+    const html = getEmailHtml('user-created', {
+      person_name: 'Test Person',
+      username: 'tester',
+      temp_password: 'pw123',
+      domain: process.env.DOMAIN ?? '',
+    });
+
+    expect(html).toContain('Test Person');
+    expect(html).toContain('tester');
+    expect(html).toContain('Open the Secret Santa website');
+    expect(html).toContain('http://localhost:3000');
+  });
+
+  it('replaces multiple occurrences of the same variable', () => {
+    const tpl = '{{a}}-{{a}}-{{b}}';
+    const out = renderEmailTemplate(tpl, { a: 'X', b: 'Y' });
+    expect(out).toBe('X-X-Y');
+  });
+
+  it('throws when loading a non-existent template', () => {
+    expect(() => loadEmailTemplate('__this-template-does-not-exist__')).toThrow(/Email template not found/);
+  });
+
+  it('returns a default subject when template name is unknown', () => {
+    const subj = getEmailSubject('not-a-real-template', { foo: 'bar' });
+    expect(subj).toBe('Secret Santa Notification');
+  });
+});

--- a/email-templates/assignment-notification.html
+++ b/email-templates/assignment-notification.html
@@ -18,6 +18,11 @@
 				Happy gifting! 🎁<br />
 				Family Secret Santa
 			</p>
+
+			<!-- Link back to the site using the DOMAIN environment variable -> rendered as {{domain}} -->
+			<p style="margin-top: 12px; font-size: 14px">
+				<a href="{{domain}}" style="color: #4f46e5; text-decoration: none;">Open the Secret Santa website</a>
+			</p>
 		</div>
 	</body>
 </html>

--- a/email-templates/password-reset.html
+++ b/email-templates/password-reset.html
@@ -32,6 +32,11 @@
 				Happy gifting! 🎁<br />
 				Family Secret Santa
 			</p>
+
+			<!-- Link back to the site using the DOMAIN environment variable -> rendered as {{domain}} -->
+			<p style="margin-top: 12px; font-size: 14px">
+				<a href="{{domain}}" style="color: #4f46e5; text-decoration: none;">Open the Secret Santa website</a>
+			</p>
 		</div>
 	</body>
 </html>

--- a/email-templates/user-created.html
+++ b/email-templates/user-created.html
@@ -38,6 +38,11 @@
 				Happy gifting! 🎁<br />
 				Family Secret Santa
 			</p>
+
+			<!-- Link back to the site using the DOMAIN environment variable -> rendered as {{domain}} -->
+			<p style="margin-top: 12px; font-size: 14px">
+				<a href="{{domain}}" style="color: #4f46e5; text-decoration: none;">Open the Secret Santa website</a>
+			</p>
 		</div>
 	</body>
 </html>

--- a/src/app/api/send-notifications/[year]/route.ts
+++ b/src/app/api/send-notifications/[year]/route.ts
@@ -72,6 +72,7 @@ export async function POST(req: Request, { params }: { params: { year: string } 
 				giver_name: assignment.giver_name,
 				receiver_name: assignment.receiver_name,
 				wishlist_section: wishlistHtml,
+				domain: process.env.DOMAIN ?? '',
 			});
 
 			const subject = getEmailSubject('assignment-notification', {

--- a/src/app/api/users/[id]/resend-credentials/route.ts
+++ b/src/app/api/users/[id]/resend-credentials/route.ts
@@ -65,6 +65,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
 				person_name: user.person_name,
 				username: user.username,
 				temp_password: tempPassword,
+				domain: process.env.DOMAIN ?? '',
 			});
 
 			const subject = getEmailSubject('password-reset', {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -107,6 +107,7 @@ export async function POST(request: Request) {
 					person_name: person.name,
 					username: username,
 					temp_password: tempPassword,
+					domain: process.env.DOMAIN ?? '',
 				});
 
 				const subject = getEmailSubject('user-created', {


### PR DESCRIPTION
## Description

- Adds a clickable "Open the Secret Santa website" link to all email templates, using the `{{domain}}` placeholder which is populated from the `DOMAIN` environment variable.
- Passes `process.env.DOMAIN ?? ''` into the template rendering for all places that send email.
- Adds unit tests to raise coverage for `src/lib/email-config.ts` and `src/lib/email-templates.ts`, covering parsing, validation, template rendering, error paths, and default subject behavior.


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [X] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [X] ✅ Test update
- [X] 🔧 Configuration change
- [ ] 🚀 CI/CD update

## Related Issues

## Changes Made

- Modified:
  - `email-templates/assignment-notification.html` — added footer link placeholder `{{domain}}`
  - `email-templates/password-reset.html` — added footer link placeholder `{{domain}}`
  - `email-templates/user-created.html` — added footer link placeholder `{{domain}}`
  - `src/app/api/send-notifications/[year]/route.ts` — pass `domain: process.env.DOMAIN ?? ''` to `getEmailHtml`
  - `src/app/api/users/route.ts` — pass `domain: process.env.DOMAIN ?? ''` to `getEmailHtml`
  - `src/app/api/users/[id]/resend-credentials/route.ts` — pass `domain: process.env.DOMAIN ?? ''` to `getEmailHtml`
- Tests added/updated:
  - `__tests__/lib/email-config.test.ts` — new: tests for `getEnvEmailConfig()` and `isEmailConfigValid()`
  - `__tests__/lib/email-templates.test.ts` — new/extended: tests for `renderEmailTemplate()`, `getEmailSubject()`, `getEmailHtml()`, `loadEmailTemplate()` error path, and multiple-occurrence replacement
  - Small assertion fix in templates test (preserve '0' behavior)

## Screenshots/Videos
 New link at bottom of emails
<img width="610" height="221" alt="image" src="https://github.com/user-attachments/assets/aa4b26eb-c159-48fa-a3b6-eea4f160ef60" />


## Testing

- [X] Unit tests pass (`npm test`)
- [X] Linting passes (`npm run lint`)
- [X] Build succeeds (`npm run build`)
- [X] Manual testing completed

### Test Coverage

File                                                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s       
---------------------------------------|---------|----------|---------|--------- |-------------------------
email-config.ts                                 |     100   |      100  |     100  |     100   |                         
email-templates.ts                           |     100   |     87.5  |     100  |     100   | 55 


## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published
- [X] I have used [conventional commits](https://www.conventionalcommits.org/) for my commit messages

## Deployment Notes

- [ ] Database migrations required: No
- [X] Environment variable changes required: DOMAIN variable used properly now
- [ ] Breaking changes: No

## Additional Context